### PR TITLE
Client Side Support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -35,12 +35,12 @@ impl ErrorCode {
 
 	pub fn description(&self) -> String {
 		let desc = match *self {
-			ErrorCode::ParseError => "Parse error.",
-			ErrorCode::InvalidRequest => "Invalid request.",
-			ErrorCode::MethodNotFound => "Method not found.",
-			ErrorCode::InvalidParams => "Invalid params.",
-			ErrorCode::InternalError => "Internal error.",
-			ErrorCode::ServerError(_) => "Server error.",
+			ErrorCode::ParseError => "Parse error",
+			ErrorCode::InvalidRequest => "Invalid request",
+			ErrorCode::MethodNotFound => "Method not found",
+			ErrorCode::InvalidParams => "Invalid params",
+			ErrorCode::InternalError => "Internal error",
+			ErrorCode::ServerError(_) => "Server error",
 		};
 		desc.to_string()
 	}

--- a/src/request.rs
+++ b/src/request.rs
@@ -47,7 +47,7 @@ pub enum Call {
 impl Serialize for Call {
 	fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
 	where S: Serializer {
-		match * self {
+		match *self {
 			Call::MethodCall(ref m) => m.serialize(serializer),
 			Call::Notification(ref n) => n.serialize(serializer),
 			Call::Invalid => ErrorCode::InvalidRequest.serialize(serializer)
@@ -100,7 +100,7 @@ fn method_call_serialize() {
 
 	let m = MethodCall {
 		jsonrpc: Version::V2,
-		method: "update".to_string(),
+		method: "update".to_owned(),
 		params: Some(Params::Array(vec![Value::U64(1), Value::U64(2)])),
 		id: Id::Num(1)
 	};
@@ -116,7 +116,7 @@ fn notification_serialize() {
 
 	let n = Notification {
 		jsonrpc: Version::V2,
-		method: "update".to_string(),
+		method: "update".to_owned(),
 		params: Some(Params::Array(vec![Value::U64(1), Value::U64(2)]))
 	};
 
@@ -172,7 +172,7 @@ fn notification_deserialize() {
 
 	assert_eq!(deserialized, Notification {
 		jsonrpc: Version::V2,
-		method: "update".to_string(),
+		method: "update".to_owned(),
 		params: Some(Params::Array(vec![Value::U64(1), Value::U64(2)]))
 	});
 
@@ -181,7 +181,7 @@ fn notification_deserialize() {
 
 	assert_eq!(deserialized, Notification {
 		jsonrpc: Version::V2,
-		method: "foobar".to_string(),
+		method: "foobar".to_owned(),
 		params: None
 	});
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,7 +4,7 @@ use serde_json::value;
 use super::{Id, Params, Version, Value};
 
 /// Represents jsonrpc request which is a method call.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MethodCall {
 	/// A String specifying the version of the JSON-RPC protocol. 
@@ -22,7 +22,7 @@ pub struct MethodCall {
 }
 
 /// Represents jsonrpc request which is a notification.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Notification {
 	/// A String specifying the version of the JSON-RPC protocol. 
@@ -69,6 +69,40 @@ impl Deserialize for Request {
 			.or_else(|_| Deserialize::deserialize(&mut value::Deserializer::new(v.clone())).map(Request::Single))
 			.map_err(|_| Error::custom("")) // unreachable, but types must match
 	}
+}
+
+#[test]
+fn method_call_serialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let m = MethodCall {
+		jsonrpc: Version::V2,
+		method: "update".to_string(),
+		params: Some(Params::Array(vec![Value::U64(1), Value::U64(2)])),
+		id: Id::Num(1)
+	};
+
+	let serialized = serde_json::to_string(&m).unwrap();
+
+	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1}"#);
+
+}
+
+#[test]
+fn notification_serialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let n = Notification {
+		jsonrpc: Version::V2,
+		method: "update".to_string(),
+		params: Some(Params::Array(vec![Value::U64(1), Value::U64(2)]))
+	};
+
+	let serialized = serde_json::to_string(&n).unwrap();
+
+	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2]}"#);
 }
 
 #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -48,3 +48,33 @@ impl Serialize for Response {
 	}
 }
 
+#[test]
+fn success_output_serialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let so = Output::Success(Success {
+		jsonrpc: Version::V2,
+		result: Value::U64(1),
+		id: Id::Num(1)
+	});
+
+	let serialized = serde_json::to_string(&so).unwrap();
+	assert_eq!(serialized, r#"{"jsonrpc":"2.0","result":1,"id":1}"#);
+}
+
+#[test]
+fn failure_output_serialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let fo = Output::Failure(Failure {
+		jsonrpc: Version::V2,
+		error: Error::parse_error(),
+		id: Id::Num(1)
+	});
+
+	let serialized = serde_json::to_string(&fo).unwrap();
+	assert_eq!(serialized, r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}"#);
+}
+

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,21 +2,21 @@
 use serde::{Serialize, Serializer};
 use super::{Id, Value, Error, Version};
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Success {
 	pub jsonrpc: Version,
 	pub result: Value,
 	pub id: Id
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Failure {
 	pub jsonrpc: Version,
 	pub error: Error,
 	pub id: Id
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize)]
 pub enum Output {
 	Success(Success),
 	Failure(Failure)
@@ -32,7 +32,7 @@ impl Serialize for Output {
 	}
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize)]
 pub enum Response {
 	Single(Output),
 	Batch(Vec<Output>)
@@ -64,6 +64,21 @@ fn success_output_serialize() {
 }
 
 #[test]
+fn success_output_deserialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let dso = r#"{"jsonrpc":"2.0","result":1,"id":1}"#;
+
+	let deserialized: Output = serde_json::from_str(dso).unwrap();
+	assert_eq!(deserialized, Output::Success(Success {
+		jsonrpc: Version::V2,
+		result: Value::U64(1),
+		id: Id::Num(1)
+	}));
+}
+
+#[test]
 fn failure_output_serialize() {
 	use serde_json;
 	use serde_json::Value;
@@ -75,6 +90,60 @@ fn failure_output_serialize() {
 	});
 
 	let serialized = serde_json::to_string(&fo).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}"#);
+	assert_eq!(serialized, r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":null},"id":1}"#);
 }
+
+#[test]
+fn failure_output_deserialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let dfo = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}"#;
+
+	let deserialized: Output = serde_json::from_str(dfo).unwrap();
+	assert_eq!(deserialized, Output::Failure(Failure {
+		jsonrpc: Version::V2,
+		error: Error::parse_error(),
+		id: Id::Num(1)
+	}));
+}
+
+#[test]
+fn single_response_deserialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let dsr = r#"{"jsonrpc":"2.0","result":1,"id":1}"#;
+
+	let deserialized: Response = serde_json::from_str(dsr).unwrap();
+	assert_eq!(deserialized, Response::Single(Output::Success(Success {
+		jsonrpc: Version::V2,
+		result: Value::U64(1),
+		id: Id::Num(1)
+	})));
+}
+
+#[test]
+fn batch_response_deserialize() {
+	use serde_json;
+	use serde_json::Value;
+
+	let dbr = r#"[{"jsonrpc":"2.0","result":1,"id":1},{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}]"#;
+
+	let deserialized: Response = serde_json::from_str(dbr).unwrap();
+	assert_eq!(deserialized, Response::Batch(vec![
+		Output::Success(Success {
+			jsonrpc: Version::V2,
+			result: Value::U64(1),
+			id: Id::Num(1)
+		}),
+		Output::Failure(Failure {
+			jsonrpc: Version::V2,
+			error: Error::parse_error(),
+			id: Id::Num(1)
+		})
+	]));
+}
+
+
 


### PR DESCRIPTION
#7 

- [x] Implementing `Serialize` trait for:
 - [x] `MethodCall`
 - [x] `Notification`
 - [x] `Call`
 - [x] `Request`

- [x] implementing Deserialize trait for:
   - [x] Success
   - [x] Failure
   - [x] Output
   - [x] Response
   - [ ] Params

- [ ] comprehensive tests for newly added code (especially deserialization).
- [ ] easy to use Request Builder (maybe utilizing builder pattern? not sure about this one, it's optional)